### PR TITLE
libocr update + dataSource fix

### DIFF
--- a/core/services/data_source.go
+++ b/core/services/data_source.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/smartcontractkit/chainlink-relay/core/server/webhook"
@@ -67,16 +68,25 @@ func (dss *dataSourceState) Observe(ctx context.Context) error {
 	// set observation request started
 	dss.Log.Infof("[%s] Observe (job run) triggered", dss.ID)
 	dss.Done = make(chan struct{}) // create channel for signaling finish
+	defer close(dss.Done)          // close channel to indicate done
 
 	// send job trigger
 	go dss.Webhook.TriggerJob(dss.ID)
 
-	// wait for job run data to be returned
-	dss.Prices[priceFeedParam] = <-*dss.RunData // use first value
-	dss.Prices[juelsToXParam] = <-*dss.RunData  // use second value
+	// wait for job run data to be returned (each channel read is wrapped with ctx.Done())
+	select {
+	case dss.Prices[priceFeedParam] = <-*dss.RunData: // use first value
+	case <-ctx.Done():
+		return fmt.Errorf("[%s] Observe (job run) cancelled", dss.ID)
+	}
+	select {
+	case dss.Prices[juelsToXParam] = <-*dss.RunData: // use second value
+	case <-ctx.Done():
+		return fmt.Errorf("[%s] Observe (job run) cancelled", dss.ID)
+	}
+
 	dss.Log.Infof("[%s] Observation (job run) received: %+v", dss.ID, dss.Prices)
 
-	close(dss.Done) // close channel to indicate done
 	return nil
 }
 
@@ -97,9 +107,13 @@ func (ds dataSource) Observe(ctx context.Context) (*big.Int, error) {
 	case errAlreadyTriggered: // occrus when observe has already been triggered
 		ds.dss.Log.Infof("[%s - %s] Waiting for observe job run to complete", ds.dss.ID, ds.Key)
 		// once observe is complete (channel closure)
-		<-ds.dss.Done
+		select {
+		case <-ds.dss.Done: // continue (successful completion)
+		case <-ctx.Done():
+			return big.NewInt(0), fmt.Errorf("[%s - %s] Observe context cancelled", ds.dss.ID, ds.Key)
+		}
 	default: // return if unknown error
-		return big.NewInt(0), err
+		return big.NewInt(0), fmt.Errorf("[%s - %s] %w", ds.dss.ID, ds.Key, err)
 	}
 
 	// return specific price data from state


### PR DESCRIPTION
Updating the libocr version

DataSource changes:
* using `uber/atomic` (safer library then the built in `atomic` module)
* implemented `ctx.Done()` handling
  * noticed once it happen once, but `Observe` can potentially freeze if data is not returned.
  * each time there is a wait for a channel response, added a `select` statement to also allow `ctx.Done()` to stop the function