### PR TITLE
Fix for running on macOS

### DIFF
--- a/ops/adapter/container.go
+++ b/ops/adapter/container.go
@@ -28,7 +28,7 @@ func New(ctx *pulumi.Context, img *utils.Image, i int) (client.BridgeTypeAttribu
 
 	_, err = docker.NewContainer(ctx, name+"-adapter", &docker.ContainerArgs{
 		Image:       img.Img.Name,
-		NetworkMode: pulumi.String(config.Get(ctx, "NETWORK_NAME")),
+		NetworkMode: pulumi.String(utils.GetDefaultNetworkName(ctx)),
 		Envs:        pulumi.StringArrayInput(pulumi.ToStringArray(envs)),
 		Hostname:    pulumi.String(name + "-adapter"),
 		Ports: docker.ContainerPortArray{

--- a/ops/adapter/container.go
+++ b/ops/adapter/container.go
@@ -27,15 +27,17 @@ func New(ctx *pulumi.Context, img *utils.Image, i int) (client.BridgeTypeAttribu
 	name := strings.Split(img.Name, "-")[0]
 
 	_, err = docker.NewContainer(ctx, name+"-adapter", &docker.ContainerArgs{
-		Image: img.Img.Name,
-		Envs:  pulumi.StringArrayInput(pulumi.ToStringArray(envs)),
+		Image:       img.Img.Name,
+		NetworkMode: pulumi.String(config.Get(ctx, "NETWORK_NAME")),
+		Envs:        pulumi.StringArrayInput(pulumi.ToStringArray(envs)),
+		Hostname:    pulumi.String(name + "-adapter"),
 		Ports: docker.ContainerPortArray{
 			docker.ContainerPortArgs{
-				Internal: pulumi.Int(8080),
+				Internal: pulumi.Int(port),
 				External: pulumi.Int(port + i),
 			},
 		},
 	})
 
-	return client.BridgeTypeAttributes{Name: name, URL: fmt.Sprintf("http://localhost:%d", port+i)}, err
+	return client.BridgeTypeAttributes{Name: name, URL: fmt.Sprintf("http://%s-adapter:%d", name, port)}, err
 }

--- a/ops/chainlink/container.go
+++ b/ops/chainlink/container.go
@@ -76,7 +76,7 @@ func New(ctx *pulumi.Context, image *utils.Image, dbPort int, index int) (Node, 
 	_, err = docker.NewContainer(ctx, node.Name, &docker.ContainerArgs{
 		Image:       imageName,
 		Logs:        pulumi.BoolPtr(true),
-		NetworkMode: pulumi.String(config.Get(ctx, "NETWORK_NAME")),
+		NetworkMode: pulumi.String(utils.GetDefaultNetworkName(ctx)),
 		Hostname:    pulumi.String("chainlink-" + indexStr),
 		Ports: docker.ContainerPortArray{
 			docker.ContainerPortArgs{
@@ -93,6 +93,12 @@ func New(ctx *pulumi.Context, image *utils.Image, dbPort int, index int) (Node, 
 		Entrypoints:   entrypoints.ToStringArrayOutput(),
 		Restart:       pulumi.String("on-failure"),
 		MaxRetryCount: pulumi.Int(3),
+		Hosts: docker.ContainerHostArray{
+			docker.ContainerHostArgs{
+				Host: pulumi.String("host.docker.internal"),
+				Ip:   pulumi.String("host-gateway"),
+			},
+		},
 		// Attach:        pulumi.BoolPtr(true),
 	})
 	return node, err

--- a/ops/chainlink/node.go
+++ b/ops/chainlink/node.go
@@ -43,7 +43,7 @@ func (n *Node) Health() (interface{}, error) {
 // Ready checks when node is ready
 func (n *Node) Ready() error {
 	msg := utils.LogStatus(fmt.Sprintf("Waiting for health checks on %s", n.Name))
-	timeout := 30
+	timeout := 300
 	var err error
 	time.Sleep(2 * time.Second) // removing this breaks running `up` multiple times...
 	for i := 0; i < timeout; i++ {

--- a/ops/core.go
+++ b/ops/core.go
@@ -111,8 +111,6 @@ func New(ctx *pulumi.Context, deployer Deployer, obsSource ObservationSource, ju
 
 	// create network
 	nwName := utils.GetDefaultNetworkName(ctx)
-	fmt.Printf("nwName %s\n", nwName)
-	println(nwName)
 	_, err := utils.CreateNetwork(ctx, nwName)
 
 	if err != nil {

--- a/ops/core.go
+++ b/ops/core.go
@@ -109,8 +109,10 @@ func New(ctx *pulumi.Context, deployer Deployer, obsSource ObservationSource, ju
 		return fmt.Errorf("Minimum number of chainlink nodes (4) not met (%d)", nodeNum)
 	}
 
-	// create network pulumi-local
-	nwName := config.Get(ctx, "NETWORK_NAME")
+	// create network
+	nwName := utils.GetDefaultNetworkName(ctx)
+	fmt.Printf("nwName %s\n", nwName)
+	println(nwName)
 	_, err := utils.CreateNetwork(ctx, nwName)
 
 	if err != nil {

--- a/ops/core.go
+++ b/ops/core.go
@@ -109,6 +109,14 @@ func New(ctx *pulumi.Context, deployer Deployer, obsSource ObservationSource, ju
 		return fmt.Errorf("Minimum number of chainlink nodes (4) not met (%d)", nodeNum)
 	}
 
+	// create network pulumi-local
+	nwName := config.Get(ctx, "NETWORK_NAME")
+	_, err := utils.CreateNetwork(ctx, nwName)
+
+	if err != nil {
+		return err
+	}
+
 	// start pg + create DBs
 	db, err := database.New(ctx, img["psql"].Img)
 	if err != nil {

--- a/ops/database/container.go
+++ b/ops/database/container.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pulumi/pulumi-docker/sdk/v3/go/docker"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+	"github.com/smartcontractkit/chainlink-relay/ops/utils"
 )
 
 // New spins up a postgres db docker image
@@ -29,7 +30,7 @@ func New(ctx *pulumi.Context, image *docker.RemoteImage) (Database, error) {
 	_, err = docker.NewContainer(ctx, "postgres", &docker.ContainerArgs{
 		Image:       image.Name,
 		Envs:        pulumi.StringArrayInput(pulumi.ToStringArray([]string{"POSTGRES_HOST_AUTH_METHOD=trust"})),
-		NetworkMode: pulumi.String(config.Get(ctx, "NETWORK_NAME")),
+		NetworkMode: pulumi.String(utils.GetDefaultNetworkName(ctx)),
 		Hostname:    pulumi.String("postgres"),
 		Ports: docker.ContainerPortArray{
 			docker.ContainerPortArgs{

--- a/ops/database/container.go
+++ b/ops/database/container.go
@@ -27,8 +27,10 @@ func New(ctx *pulumi.Context, image *docker.RemoteImage) (Database, error) {
 	}
 
 	_, err = docker.NewContainer(ctx, "postgres", &docker.ContainerArgs{
-		Image: image.Name,
-		Envs:  pulumi.StringArrayInput(pulumi.ToStringArray([]string{"POSTGRES_HOST_AUTH_METHOD=trust"})),
+		Image:       image.Name,
+		Envs:        pulumi.StringArrayInput(pulumi.ToStringArray([]string{"POSTGRES_HOST_AUTH_METHOD=trust"})),
+		NetworkMode: pulumi.String(config.Get(ctx, "NETWORK_NAME")),
+		Hostname:    pulumi.String("postgres"),
 		Ports: docker.ContainerPortArray{
 			docker.ContainerPortArgs{
 				Internal: pulumi.Int(5432),

--- a/ops/utils/network.go
+++ b/ops/utils/network.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"github.com/pulumi/pulumi-docker/sdk/v3/go/docker"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 // Create network
@@ -13,4 +14,12 @@ func CreateNetwork(ctx *pulumi.Context, nwName string) (*docker.Network, error) 
 		return network, err
 	}
 	return network, err
+}
+
+func GetDefaultNetworkName(ctx *pulumi.Context) string {
+	name := config.Get(ctx, "NETWORK_NAME")
+	if name != "" {
+		return name
+	}
+	return "pulumi-local"
 }

--- a/ops/utils/network.go
+++ b/ops/utils/network.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"github.com/pulumi/pulumi-docker/sdk/v3/go/docker"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// Create network
+func CreateNetwork(ctx *pulumi.Context, nwName string) (*docker.Network, error) {
+	network, err := docker.GetNetwork(ctx, nwName, nil, nil, nil)
+	if err != nil {
+		network, err := docker.NewNetwork(ctx, nwName, &docker.NetworkArgs{Name: pulumi.String(nwName)}, nil)
+		return network, err
+	}
+	return network, err
+}


### PR DESCRIPTION
## Problem
Docker's host networking is supported only on Linux (https://docs.docker.com/network/host/). This makes it difficult to run this pulumi stack on macOS.

## Solution
- Create a bridge docker network and run all containers on it.
- Adjust port mapping and network related envs.

## Additional
- Increase timeout in ready check (To compensate for delay in M1 Macs due to emulation. This is required until we have arm64 images available for chainlink).