### PR TITLE
common utilities from core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2
 	github.com/golang/protobuf v1.5.2
 	github.com/linkedin/goavro v2.1.0+incompatible
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.0
 	github.com/riferrei/srclient v0.4.1-0.20211229125508-8edc580da179
 	github.com/smartcontractkit/libocr v0.0.0-20211210213233-5443fb9db7f7
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/atomic v1.7.0
 	go.uber.org/goleak v1.1.12
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0
@@ -24,14 +26,12 @@ require (
 	github.com/linkedin/goavro/v2 v2.9.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"context"
+
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
+	"github.com/smartcontractkit/libocr/offchainreporting2/types"
+)
+
+type Service interface {
+	Start(context.Context) error
+	Close() error
+	Ready() error
+	Healthy() error
+}
+
+// PluginArgs are the args required to create any OCR2 plugin components.
+// Its possible that the plugin config might actually be different
+// per relay type, so we pass the config directly through.
+type PluginArgs struct {
+	TransmitterID string
+	PluginConfig  []byte
+}
+
+type RelayArgs struct {
+	ExternalJobID uuid.UUID
+	JobID         int32
+	ContractID    string
+	RelayConfig   []byte
+}
+
+type Relayer interface {
+	Service
+	NewConfigProvider(rargs RelayArgs) (ConfigProvider, error)
+	NewMedianProvider(rargs RelayArgs, pargs PluginArgs) (MedianProvider, error)
+}
+
+// The bootstrap jobs only watch config.
+type ConfigProvider interface {
+	Service
+	OffchainConfigDigester() types.OffchainConfigDigester
+	ContractConfigTracker() types.ContractConfigTracker
+}
+
+// Plugin provides common components for any OCR2 plugin.
+// It watches config and is able to transmit.
+type Plugin interface {
+	ConfigProvider
+	ContractTransmitter() types.ContractTransmitter
+}
+
+// MedianProvider provides all components needed for a median OCR2 plugin.
+type MedianProvider interface {
+	Plugin
+	ReportCodec() median.ReportCodec
+	MedianContract() median.MedianContract
+}

--- a/pkg/utils/duration.go
+++ b/pkg/utils/duration.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Duration is a non-negative time duration.
+type Duration struct{ d time.Duration }
+
+func NewDuration(d time.Duration) (Duration, error) {
+	if d < time.Duration(0) {
+		return Duration{}, fmt.Errorf("cannot make negative time duration: %s", d)
+	}
+	return Duration{d: d}, nil
+}
+
+func (d Duration) Duration() time.Duration {
+	return d.d
+}
+
+func (d Duration) String() string {
+	return d.d.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (d *Duration) UnmarshalJSON(input []byte) error {
+	var txt string
+	err := json.Unmarshal(input, &txt)
+	if err != nil {
+		return err
+	}
+	v, err := time.ParseDuration(string(txt))
+	if err != nil {
+		return err
+	}
+	*d, err = NewDuration(v)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalText implements the text.Marshaler interface.
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(d.d.String()), nil
+}
+
+// UnmarshalText implements the text.Unmarshaler interface.
+func (d *Duration) UnmarshalText(input []byte) error {
+	v, err := time.ParseDuration(string(input))
+	if err != nil {
+		return err
+	}
+	pd, err := NewDuration(v)
+	if err != nil {
+		return err
+	}
+	*d = pd
+	return nil
+}
+
+func (d *Duration) Scan(v interface{}) (err error) {
+	switch tv := v.(type) {
+	case int64:
+		*d, err = NewDuration(time.Duration(tv))
+		return err
+	default:
+		return errors.Errorf(`don't know how to parse "%s" of type %T as a `+
+			`models.Duration`, tv, tv)
+	}
+}
+
+func (d Duration) Value() (driver.Value, error) {
+	return int64(d.d), nil
+}

--- a/pkg/utils/start_stop_once.go
+++ b/pkg/utils/start_stop_once.go
@@ -1,0 +1,157 @@
+package utils
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/pkg/errors"
+	"go.uber.org/atomic"
+)
+
+type errNotStarted struct {
+	state startStopOnceState
+}
+
+func (e *errNotStarted) Error() string {
+	return fmt.Sprintf("service is %q, not started", e.state)
+}
+
+// startStopOnceState holds the state for StartStopOnce
+type startStopOnceState int32
+
+const (
+	startStopOnceUnstarted startStopOnceState = iota
+	startStopOnceStarted
+	startStopOnceStarting
+	startStopOnceStopping
+	startStopOnceStopped
+)
+
+func (s startStopOnceState) String() string {
+	switch s {
+	case startStopOnceUnstarted:
+		return "Unstarted"
+	case startStopOnceStarted:
+		return "Started"
+	case startStopOnceStarting:
+		return "Starting"
+	case startStopOnceStopping:
+		return "Stopping"
+	case startStopOnceStopped:
+		return "Stopped"
+	default:
+		return fmt.Sprintf("unrecognized state: %d", s)
+	}
+}
+
+// StartStopOnce contains a startStopOnceState integer
+type StartStopOnce struct {
+	state        atomic.Int32
+	sync.RWMutex // lock is held during startup/shutdown, RLock is held while executing functions dependent on a particular state
+}
+
+// StartOnce sets the state to Started
+func (s *StartStopOnce) StartOnce(name string, fn func() error) error {
+	// SAFETY: We do this compare-and-swap outside of the lock so that
+	// concurrent StartOnce() calls return immediately.
+	success := s.state.CAS(int32(startStopOnceUnstarted), int32(startStopOnceStarting))
+
+	if !success {
+		return errors.Errorf("%v has already started once", name)
+	}
+
+	s.Lock()
+	defer s.Unlock()
+
+	err := fn()
+
+	success = s.state.CAS(int32(startStopOnceStarting), int32(startStopOnceStarted))
+
+	if !success {
+		// SAFETY: If this is reached, something must be very wrong: once.state
+		// was tampered with outside of the lock.
+		panic(fmt.Sprintf("%v entered unreachable state, unable to set state to started", name))
+	}
+
+	return err
+}
+
+// StopOnce sets the state to Stopped
+func (s *StartStopOnce) StopOnce(name string, fn func() error) error {
+	// SAFETY: We hold the lock here so that Stop blocks until StartOnce
+	// executes. This ensures that a very fast call to Stop will wait for the
+	// code to finish starting up before teardown.
+	s.Lock()
+	defer s.Unlock()
+
+	success := s.state.CAS(int32(startStopOnceStarted), int32(startStopOnceStopping))
+
+	if !success {
+		return errors.Errorf("%v is unstarted or has already stopped once", name)
+	}
+
+	err := fn()
+
+	success = s.state.CAS(int32(startStopOnceStopping), int32(startStopOnceStopped))
+
+	if !success {
+		// SAFETY: If this is reached, something must be very wrong: once.state
+		// was tampered with outside of the lock.
+		panic(fmt.Sprintf("%v entered unreachable state, unable to set state to stopped", name))
+	}
+
+	return err
+}
+
+// State retrieves the current state
+func (s *StartStopOnce) State() startStopOnceState {
+	state := s.state.Load()
+	return startStopOnceState(state)
+}
+
+// IfStarted runs the func and returns true only if started, otherwise returns false
+func (s *StartStopOnce) IfStarted(f func()) (ok bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	state := s.state.Load()
+
+	if startStopOnceState(state) == startStopOnceStarted {
+		f()
+		return true
+	}
+	return false
+}
+
+// IfNotStopped runs the func and returns true if in any state other than Stopped
+func (s *StartStopOnce) IfNotStopped(f func()) (ok bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	state := s.state.Load()
+
+	if startStopOnceState(state) == startStopOnceStopped {
+		return false
+	}
+	f()
+	return true
+}
+
+// Ready returns ErrNotStarted if the state is not started.
+func (s *StartStopOnce) Ready() error {
+	state := s.State()
+	if state == startStopOnceStarted {
+		return nil
+	}
+	return &errNotStarted{state: state}
+}
+
+// Healthy returns ErrNotStarted if the state is not started.
+// Override this per-service with more specific implementations.
+func (s *StartStopOnce) Healthy() error {
+	state := s.State()
+	if state == startStopOnceStarted {
+		return nil
+	}
+	return &errNotStarted{state: state}
+}

--- a/pkg/utils/start_stop_once.go
+++ b/pkg/utils/start_stop_once.go
@@ -44,7 +44,7 @@ func (s startStopOnceState) String() string {
 	}
 }
 
-// StartStopOnce contains a startStopOnceState integer
+// StartStopOnce can be embedded in a struct to help implement types.Service.
 type StartStopOnce struct {
 	state        atomic.Int32
 	sync.RWMutex // lock is held during startup/shutdown, RLock is held while executing functions dependent on a particular state

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"context"
+	mrand "math/rand"
+	"time"
+)
+
+// WithJitter adds +/- 10% to a duration
+func WithJitter(d time.Duration) time.Duration {
+	// #nosec
+	if d == 0 {
+		return 0
+	}
+	jitter := mrand.Intn(int(d) / 5)
+	jitter = jitter - (jitter / 2)
+	return time.Duration(int(d) + jitter)
+}
+
+// ContextFromChan creates a context that finishes when the provided channel
+// receives or is closed.
+// When channel closes, the ctx.Err() will always be context.Canceled
+// NOTE: Spins up a goroutine that exits on cancellation.
+// REMEMBER TO CALL CANCEL OTHERWISE IT CAN LEAD TO MEMORY LEAKS
+func ContextFromChan(chStop <-chan struct{}) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-chStop:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/39857/remove-chainlink-terra-solana-chainlink-core-dependency-to-resolve-cycle
Copying a minimal set of utilities from core to break the cycles.
- [x] `models.Duration` => `utils.Duration`
- [x] `utils.StartStopOnce`, `utils.ContextFromChan` and `utils.WithJitter`
- [x] `services.Service`
- [x] `relay/types`

Supporting:
- https://github.com/smartcontractkit/chainlink-terra/pull/290
- https://github.com/smartcontractkit/chainlink-solana/pull/342