### PR TITLE
Don't error when metrics can't be deleted

### DIFF
--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -1,7 +1,6 @@
 package monitoring
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -619,13 +618,7 @@ func (d *defaultMetrics) Cleanup(
 			},
 		},
 	} {
-		if !metric.vec.Delete(metric.labels) {
-			errArgs := []interface{}{}
-			for key, value := range metric.labels {
-				errArgs = append(errArgs, key, value)
-			}
-			d.log.Errorw(fmt.Sprintf("unable to delete metric '%s'", metric.name), errArgs...)
-		}
+		metric.vec.Delete(metric.labels)
 	}
 }
 


### PR DESCRIPTION
When a metric can't be deleted because it hasn't been instantiated before, don't log an error