### PR TITLE
Add ParseSchema for avro.Schema objects

### DIFF
--- a/pkg/monitoring/avro/helpers.go
+++ b/pkg/monitoring/avro/helpers.go
@@ -1,0 +1,21 @@
+package avro
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/linkedin/goavro"
+)
+
+func ParseSchema(schema Schema) (jsonEncodedSchema string, codec *goavro.Codec, err error) {
+	buf, err := json.Marshal(schema)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to encode Avro schema to JSON: %w", err)
+	}
+	jsonEncodedSchema = string(buf)
+	codec, err = goavro.NewCodec(jsonEncodedSchema)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to parse JSON-encoded Avro schema into a codec: %w", err)
+	}
+	return jsonEncodedSchema, codec, nil
+}


### PR DESCRIPTION
This is just a helper that I found myself writing in both terra and solana on-chain monitors. 