### PR TITLE
Revert "Add OCR2VRF+DKG relay types"

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -57,20 +57,3 @@ type MedianProvider interface {
 	ReportCodec() median.ReportCodec
 	MedianContract() median.MedianContract
 }
-
-// OCR2VRFRelayer contains the relayer and instantiating functions for OCR2VRF providers.
-type OCR2VRFRelayer interface {
-	Relayer
-	NewDKGProvider(rargs RelayArgs, transmitterID string) (DKGProvider, error)
-	NewOCR2VRFProvider(rargs RelayArgs, transmitterID string) (OCR2VRFProvider, error)
-}
-
-// DKGProvider provides all components needed for a DKG plugin.
-type DKGProvider interface {
-	Plugin
-}
-
-// OCR2VRFProvider provides all components needed for a OCR2VRF plugin.
-type OCR2VRFProvider interface {
-	Plugin
-}


### PR DESCRIPTION
This reverts commit 49e57dd1264e313336fc2f41408efea9cf5f816d.

Getting rid of all work done here. For now we'll just override relay types in the main Chainlink package.