### PR TITLE
Add relayer arg AllowForwarding to propagate to transmitters

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -25,10 +25,11 @@ type PluginArgs struct {
 }
 
 type RelayArgs struct {
-	ExternalJobID uuid.UUID
-	JobID         int32
-	ContractID    string
-	RelayConfig   []byte
+	ExternalJobID     uuid.UUID
+	JobID             int32
+	ContractID        string
+	ForwardingAllowed bool
+	RelayConfig       []byte
 }
 
 type Relayer interface {


### PR DESCRIPTION
This change adds AllowForwarding relayer arg to propogate jobspec field to the contract transmitters. This field is false by default and is only set if the jobspec value is set. It should be backward compatible with current uses of relayer as well