### PR TITLE
Remove forwardingAllowed from relayerArgs

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -25,11 +25,10 @@ type PluginArgs struct {
 }
 
 type RelayArgs struct {
-	ExternalJobID     uuid.UUID
-	JobID             int32
-	ContractID        string
-	ForwardingAllowed bool
-	RelayConfig       []byte
+	ExternalJobID uuid.UUID
+	JobID         int32
+	ContractID    string
+	RelayConfig   []byte
 }
 
 type Relayer interface {


### PR DESCRIPTION
this is going to be replaced with passing the attribute in the relayerCfg to avoid polluting relayerArgs