### PR TITLE
Add the simplest health endpoint possible

### DIFF
--- a/pkg/monitoring/monitor.go
+++ b/pkg/monitoring/monitor.go
@@ -3,6 +3,7 @@ package monitoring
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -120,6 +121,10 @@ func NewMonitor(
 	httpServer := NewHTTPServer(rootCtx, cfg.HTTP.Address, logger.With(log, "component", "http-server"))
 	httpServer.Handle("/metrics", metrics.HTTPHandler())
 	httpServer.Handle("/debug", manager.HTTPHandler())
+	// Required for k8s.
+	httpServer.Handle("/health", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
 
 	return &Monitor{
 		rootCtx,


### PR DESCRIPTION
TL;DR, I went with a very "dumb" health endpoint because a more complex one would not bring any benefits. 

A little context for this very small change:
- k8s tests the "healthiness" of a pod by periodically hitting a `GET /health` endpoint. If the return status is not 200, k8s takes some action; this is configurable, but by default it will restart the pod. It's my understanding that we are sticking with the default here.
- it's the job of the containerized process to decide what it means to be healthy. I've been recommended an approach whereby if the process stops having access to its dependencies, then it's unhealthy. This [example](https://github.com/smartcontractkit/notifier/blob/b508a8f13318c07fa98c1811da455016f864e7d3/pkg/system/server.go#L23) shows a process that requires a connection to a db and to redis; if either of those fail, the process decides it's unhealthy and k8s will restart it. The problem with that is that even if the process is restarted, if it couldn't connect to the db/redis/etc before the restart, there's little chance it will be able to connect afterwards. Added to that, most protocol clients (certainly mysql, postgres, redis, ie. the popular ones) will try to re-connect automatically. Personally, I think that the only thing this strategy achieves is putting A LOT of unnecessary pressure on the k8s scheduler to continuously re-assign these pods on different workers in the hope that one of them can connect to the db/redis. 
- back to our sheep; the on-chain monitor requires access to a chain client's RPC endpoint, to weiwatchers, to kafka and to a schema registry. If it can't connect to them, it can't do its job, but it doesn't mean it's not healthy. All of the client SDKs used to connect to these services will attempt re-connection transparently. 