### PR TITLE
Add HealthReport/Name to service interface

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,6 +12,7 @@ import (
 )
 
 type Service interface {
+	Name() string
 	Start(context.Context) error
 	Close() error
 	Ready() error

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -16,6 +16,7 @@ type Service interface {
 	Close() error
 	Ready() error
 	Healthy() error
+	HealthReport() map[string]error
 }
 
 // PluginArgs are the args required to create any OCR2 plugin components.


### PR DESCRIPTION
Context:

We want relays to return not only whether they are healthy or not, but a report of the underlying services and their health
This PR introduces two new fns to Service in relay

```golang
// returns the name of the service
// the recommendation here is to use logger.Name() since it provides a fully qualified name
Name() string 
// returns a map , where key is service name, value is nil if subservice is healthy and error message otherwise
HealthReport() map[service]error
```


Next steps:
-  Update relay impl repos and implement this in all relays
- Submit core node PR