### PR TITLE
pkg/types: s/Plugin/PluginProvider

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -49,16 +49,20 @@ type ConfigProvider interface {
 	ContractConfigTracker() ocrtypes.ContractConfigTracker
 }
 
-// Plugin provides common components for any OCR2 plugin.
+// Plugin is an alias for PluginProvider, for compatability.
+// Deprecated
+type Plugin = PluginProvider
+
+// PluginProvider provides common components for any OCR2 plugin.
 // It watches config and is able to transmit.
-type Plugin interface {
+type PluginProvider interface {
 	ConfigProvider
 	ContractTransmitter() ocrtypes.ContractTransmitter
 }
 
 // MedianProvider provides all components needed for a median OCR2 plugin.
 type MedianProvider interface {
-	Plugin
+	PluginProvider
 	ReportCodec() median.ReportCodec
 	MedianContract() median.MedianContract
 	OnchainConfigCodec() median.OnchainConfigCodec


### PR DESCRIPTION
Rename `Plugin` to `PluginProvider`, but leave behind an alias for compatability.