### PR TITLE
modify context deadline in dataSourceServer.Observe() to work around pipeline behavior

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,3 +34,16 @@ func ContextFromChan(chStop <-chan struct{}) (context.Context, context.CancelFun
 	}()
 	return ctx, cancel
 }
+
+// ContextWithDeadlineFn returns a copy of the parent context with the deadline modified by deadlineFn.
+// deadlineFn will only be called if the parent has a deadline.
+// The new deadline must be sooner than the old to have an effect.
+func ContextWithDeadlineFn(ctx context.Context, deadlineFn func(orig time.Time) time.Time) (context.Context, context.CancelFunc) {
+	cancel := func() {}
+	if d, ok := ctx.Deadline(); ok {
+		if m := deadlineFn(d); m.Before(d) {
+			ctx, cancel = context.WithDeadline(ctx, m)
+		}
+	}
+	return ctx, cancel
+}


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-2176

Core bump: https://github.com/smartcontractkit/chainlink/pull/9083

Follow up in https://smartcontract-it.atlassian.net/browse/BCF-2209