### PR TITLE
refactor median plugin

### DIFF
--- a/pkg/loop/internal/config.go
+++ b/pkg/loop/internal/config.go
@@ -8,7 +8,7 @@ import (
 
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2/types"
 
-	pb "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
 )
 

--- a/pkg/loop/internal/datasource.go
+++ b/pkg/loop/internal/datasource.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 
-	pb "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
 	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
 )
 

--- a/pkg/loop/internal/error_log.go
+++ b/pkg/loop/internal/error_log.go
@@ -6,7 +6,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	pb "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
 )
 
 var _ ErrorLog = (*errorLogClient)(nil)

--- a/pkg/loop/internal/provider.go
+++ b/pkg/loop/internal/provider.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smartcontractkit/libocr/commontypes"
 	libocr "github.com/smartcontractkit/libocr/offchainreporting2/types"
 
-	pb "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
 )
 
 var _ libocr.ContractTransmitter = (*contractTransmitterClient)(nil)

--- a/pkg/loop/internal/relayer.go
+++ b/pkg/loop/internal/relayer.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
-	pb "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
 )
 

--- a/pkg/loop/internal/service.go
+++ b/pkg/loop/internal/service.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	pb "github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/pb"
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
 )
 

--- a/pkg/loop/internal/test/datasource.go
+++ b/pkg/loop/internal/test/datasource.go
@@ -15,6 +15,10 @@ type staticDataSource struct {
 	value *big.Int
 }
 
+func StaticDataSource() median.DataSource { return &staticDataSource{value} }
+
+func StaticJuelsPerFeeCoinDataSource() median.DataSource { return &staticDataSource{juelsPerFeeCoin} }
+
 func (s *staticDataSource) Observe(ctx context.Context, timestamp types.ReportTimestamp) (*big.Int, error) {
 	if timestamp != reportContext.ReportTimestamp {
 		return nil, fmt.Errorf("expected %v but got %v", reportContext.ReportTimestamp, timestamp)

--- a/pkg/loop/internal/test/error_log.go
+++ b/pkg/loop/internal/test/error_log.go
@@ -7,11 +7,11 @@ import (
 	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal"
 )
 
-var _ internal.ErrorLog = (*staticErrorLog)(nil)
+var _ internal.ErrorLog = (*StaticErrorLog)(nil)
 
-type staticErrorLog struct{}
+type StaticErrorLog struct{}
 
-func (s *staticErrorLog) SaveError(ctx context.Context, msg string) error {
+func (s *StaticErrorLog) SaveError(ctx context.Context, msg string) error {
 	if msg != errMsg {
 		return fmt.Errorf("expected %q but got %q", errMsg, msg)
 	}

--- a/pkg/loop/internal/test/relayer.go
+++ b/pkg/loop/internal/test/relayer.go
@@ -83,7 +83,7 @@ func (s staticRelayer) NewMedianProvider(ctx context.Context, r types.RelayArgs,
 	if !reflect.DeepEqual(pargs, p) {
 		return nil, fmt.Errorf("expected plugin args %v but got %v", pargs, p)
 	}
-	return staticMedianProvider{}, nil
+	return StaticMedianProvider{}, nil
 }
 
 func (s staticRelayer) NewMercuryProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.MercuryProvider, error) {

--- a/pkg/loop/median_service.go
+++ b/pkg/loop/median_service.go
@@ -10,33 +10,36 @@ import (
 
 	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
 )
 
-var _ PluginMedian = (*MedianService)(nil)
+var _ ocrtypes.ReportingPluginFactory = (*MedianService)(nil)
 
 // MedianService is a [types.Service] that maintains an internal [PluginMedian].
 type MedianService struct {
-	*pluginService[*GRPCPluginMedian, PluginMedian]
+	*pluginService[*GRPCPluginMedian, ReportingPluginFactory]
 }
 
 // NewMedianService returns a new [*MedianService].
 // cmd must return a new exec.Cmd each time it is called.
-func NewMedianService(lggr logger.Logger, cmd func() *exec.Cmd) *MedianService {
-	newService := func(ctx context.Context, instance any) (PluginMedian, error) {
+func NewMedianService(lggr logger.Logger, cmd func() *exec.Cmd, provider types.MedianProvider, dataSource, juelsPerFeeCoin median.DataSource, errorLog ErrorLog) *MedianService {
+	newService := func(ctx context.Context, instance any) (ReportingPluginFactory, error) {
 		plug, ok := instance.(PluginMedian)
 		if !ok {
 			return nil, fmt.Errorf("expected PluginMedian but got %T", instance)
 		}
-		return plug, nil
+		return plug.NewMedianFactory(ctx, provider, dataSource, juelsPerFeeCoin, errorLog)
 	}
 	stopCh := make(chan struct{})
 	lggr = logger.Named(lggr, "MedianService")
 	return &MedianService{newPluginService(PluginMedianName, &GRPCPluginMedian{StopCh: stopCh, Logger: lggr}, newService, lggr, cmd, stopCh)}
 }
 
-func (m *MedianService) NewMedianFactory(ctx context.Context, provider types.MedianProvider, dataSource, juelsPerFeeCoin median.DataSource, errorLog ErrorLog) (ocrtypes.ReportingPluginFactory, error) {
+func (m *MedianService) NewReportingPlugin(config ocrtypes.ReportingPluginConfig) (ocrtypes.ReportingPlugin, ocrtypes.ReportingPluginInfo, error) {
+	ctx, cancel := utils.ContextFromChan(m.pluginService.stopCh)
+	defer cancel()
 	if err := m.wait(ctx); err != nil {
-		return nil, err
+		return nil, ocrtypes.ReportingPluginInfo{}, err
 	}
-	return m.service.NewMedianFactory(ctx, provider, dataSource, juelsPerFeeCoin, errorLog)
+	return m.service.NewReportingPlugin(config)
 }

--- a/pkg/loop/median_service_test.go
+++ b/pkg/loop/median_service_test.go
@@ -20,13 +20,13 @@ func TestMedianService(t *testing.T) {
 	t.Parallel()
 	median := loop.NewMedianService(logger.Test(t), func() *exec.Cmd {
 		return helperProcess(loop.PluginMedianName)
-	})
+	}, test.StaticMedianProvider{}, test.StaticDataSource(), test.StaticJuelsPerFeeCoinDataSource(), &test.StaticErrorLog{})
 	hook := median.TestHook()
 	require.NoError(t, median.Start(utils.Context(t)))
 	t.Cleanup(func() { assert.NoError(t, median.Close()) })
 
 	t.Run("control", func(t *testing.T) {
-		test.TestPluginMedian(t, median)
+		test.TestReportingPluginFactory(t, median)
 	})
 
 	t.Run("Kill", func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestMedianService(t *testing.T) {
 		// wait for relaunch
 		time.Sleep(2 * loop.KeepAliveTickDuration)
 
-		test.TestPluginMedian(t, median)
+		test.TestReportingPluginFactory(t, median)
 	})
 
 	t.Run("Reset", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestMedianService(t *testing.T) {
 		// wait for relaunch
 		time.Sleep(2 * loop.KeepAliveTickDuration)
 
-		test.TestPluginMedian(t, median)
+		test.TestReportingPluginFactory(t, median)
 	})
 }
 
@@ -53,9 +53,9 @@ func TestMedianService_recovery(t *testing.T) {
 	var limit atomic.Int32
 	median := loop.NewMedianService(logger.Test(t), func() *exec.Cmd {
 		return helperProcess(loop.PluginMedianName, strconv.Itoa(int(limit.Add(1))))
-	})
+	}, test.StaticMedianProvider{}, test.StaticDataSource(), test.StaticJuelsPerFeeCoinDataSource(), &test.StaticErrorLog{})
 	require.NoError(t, median.Start(utils.Context(t)))
 	t.Cleanup(func() { assert.NoError(t, median.Close()) })
 
-	test.TestPluginMedian(t, median)
+	test.TestReportingPluginFactory(t, median)
 }

--- a/pkg/loop/plugin_median.go
+++ b/pkg/loop/plugin_median.go
@@ -24,6 +24,8 @@ func PluginMedianHandshakeConfig() plugin.HandshakeConfig {
 	}
 }
 
+type ReportingPluginFactory = internal.ReportingPluginFactory
+
 type GRPCPluginMedian struct {
 	plugin.NetRPCUnsupportedPlugin
 


### PR DESCRIPTION
This PR aligns `MedianService` with `RelayerService` by having it extend the `ReportingPluginFactory` rather than the root `PluginMedian`. Before this change, a `ReportingPluginFactory` could not be obtained before calling `MedianService.Start`, which was causing core job initialization to hang indefinitely. Now `MedianService` implements `ReportingPluginFactory` directly and can be passed along to dependents before calling `Start`.

Supports:
- https://github.com/smartcontractkit/chainlink/pull/9243

Note: This will need a rebase after merging #110