### PR TITLE
pkg/loop: improve docs; align service method signatures

### DIFF
--- a/pkg/loop/README.md
+++ b/pkg/loop/README.md
@@ -6,15 +6,27 @@ Local out of process (LOOP) plugins using [github.com/hashicorp/go-plugin](https
 
 ```mermaid
 flowchart
-    loop
-    internal[loop/internal]
-    pb[loop/internal/pb]
-    test[loop/internal/test]
+    subgraph chainlink-relay/pkg
+        loop
+        internal[loop/internal]
+        pb[loop/internal/pb]
+        test[loop/internal/test]
 
-    internal --> pb
-    test --> internal
-    loop --> internal
-    loop --> test
+        internal --> pb
+        test --> internal
+        loop --> internal
+        loop --> test
+    end
+    
+    grpc[google.golang.org/grpc]
+    hashicorp[hashicorp/go-plugin]
+
+    loop ---> hashicorp
+    loop ---> grpc
+    test ---> grpc
+    internal ---> grpc
+    pb ---> grpc
+    hashicorp --> grpc
 
 ```
 

--- a/pkg/loop/internal/client.go
+++ b/pkg/loop/internal/client.go
@@ -87,7 +87,7 @@ func (c *clientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, metho
 	return nil, context.Cause(ctx)
 }
 
-// refresh replaces c.cc with a new (different than orig) *grpc.ClientConn, and returns it as well.
+// refresh replaces c.cc with a new (different from orig) *grpc.ClientConn, and returns it as well.
 // It will block until a new connection is successfully dialed, or return nil if the context expires.
 func (c *clientConn) refresh(ctx context.Context, orig *grpc.ClientConn) *grpc.ClientConn {
 	c.mu.Lock()
@@ -148,6 +148,8 @@ func (c *clientConn) refresh(ctx context.Context, orig *grpc.ClientConn) *grpc.C
 	return c.cc
 }
 
+// isErrTerminal returns true if the grpc [status] [codes.Code] indicates that the plugin connection has terminated and
+// must be refreshed.
 func isErrTerminal(err error) bool {
 	switch status.Code(err) {
 	case codes.Unavailable, codes.Canceled:

--- a/pkg/loop/internal/relayer.go
+++ b/pkg/loop/internal/relayer.go
@@ -161,6 +161,7 @@ func (k *keystoreServer) Sign(ctx context.Context, request *pb.SignRequest) (*pb
 	return &pb.SignReply{SignedData: signed}, nil
 }
 
+// Relayer extends [types.Relayer] and includes [context.Context]s.
 type Relayer interface {
 	types.Service
 

--- a/pkg/loop/median_service.go
+++ b/pkg/loop/median_service.go
@@ -17,7 +17,7 @@ var _ ocrtypes.ReportingPluginFactory = (*MedianService)(nil)
 
 // MedianService is a [types.Service] that maintains an internal [PluginMedian].
 type MedianService struct {
-	*pluginService[*GRPCPluginMedian, ReportingPluginFactory]
+	pluginService[*GRPCPluginMedian, ReportingPluginFactory]
 }
 
 // NewMedianService returns a new [*MedianService].
@@ -32,7 +32,9 @@ func NewMedianService(lggr logger.Logger, cmd func() *exec.Cmd, provider types.M
 	}
 	stopCh := make(chan struct{})
 	lggr = logger.Named(lggr, "MedianService")
-	return &MedianService{newPluginService(PluginMedianName, &GRPCPluginMedian{StopCh: stopCh, Logger: lggr}, newService, lggr, cmd, stopCh)}
+	var ms MedianService
+	ms.init(PluginMedianName, &GRPCPluginMedian{StopCh: stopCh, Logger: lggr}, newService, lggr, cmd, stopCh)
+	return &ms
 }
 
 func (m *MedianService) NewReportingPlugin(config ocrtypes.ReportingPluginConfig) (ocrtypes.ReportingPlugin, ocrtypes.ReportingPluginInfo, error) {

--- a/pkg/loop/plugin_service_test.go
+++ b/pkg/loop/plugin_service_test.go
@@ -8,9 +8,9 @@ const KeepAliveTickDuration = keepAliveTickDuration
 
 // TestHook returns a TestPluginService.
 // It must only be called once, and before Start.
-func (r *pluginService[P, S]) TestHook() TestPluginService[P, S] {
-	r.testInterrupt = make(chan func(*pluginService[P, S]))
-	return r.testInterrupt
+func (s *pluginService[P, S]) TestHook() TestPluginService[P, S] {
+	s.testInterrupt = make(chan func(*pluginService[P, S]))
+	return s.testInterrupt
 }
 
 // TestPluginService supports Killing & Resetting a running *pluginService.

--- a/pkg/loop/relayer_service.go
+++ b/pkg/loop/relayer_service.go
@@ -17,7 +17,7 @@ var _ Relayer = (*RelayerService)(nil)
 
 // RelayerService is a [types.Service] that maintains an internal [Relayer].
 type RelayerService struct {
-	*pluginService[*GRPCPluginRelayer, Relayer]
+	pluginService[*GRPCPluginRelayer, Relayer]
 }
 
 // NewRelayerService returns a new [*RelayerService].
@@ -36,7 +36,9 @@ func NewRelayerService(lggr logger.Logger, cmd func() *exec.Cmd, config string, 
 	}
 	stopCh := make(chan struct{})
 	lggr = logger.Named(lggr, "RelayerService")
-	return &RelayerService{newPluginService(PluginRelayerName, &GRPCPluginRelayer{StopCh: stopCh, Logger: lggr}, newService, lggr, cmd, stopCh)}
+	var rs RelayerService
+	rs.init(PluginRelayerName, &GRPCPluginRelayer{StopCh: stopCh, Logger: lggr}, newService, lggr, cmd, stopCh)
+	return &rs
 }
 
 func (r *RelayerService) NewConfigProvider(ctx context.Context, args types.RelayArgs) (types.ConfigProvider, error) {


### PR DESCRIPTION
Misc doc improvements, and while looking at the `godoc`s I noticed that we had mixed method receivers due to embedding a pointer. Updated to embed a value, and switched the constructor to an `init` method.
![Screenshot from 2023-05-18 08-51-37](https://github.com/smartcontractkit/chainlink-relay/assets/1194128/a36afd4e-3423-4f95-965b-c5ddee85dad4)
![Screenshot from 2023-05-18 08-59-18](https://github.com/smartcontractkit/chainlink-relay/assets/1194128/99f85bca-fa11-4764-ab11-21d8c6ae8b89)
