### PR TITLE
fix panic in Jitter when used in debugger

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"math"
 	mrand "math/rand"
 	"time"
 )
@@ -12,8 +13,10 @@ func WithJitter(d time.Duration) time.Duration {
 	if d == 0 {
 		return 0
 	}
+	// ensure non-zero arg to Intn to avoid panic
+	max := math.Max(float64(d.Abs())/5.0, 1.)
 	// #nosec - non critical randomness
-	jitter := mrand.Intn(int(d) / 5)
+	jitter := mrand.Intn(int(max))
 	jitter = jitter - (jitter / 2)
 	return time.Duration(int(d) + jitter)
 }


### PR DESCRIPTION
Fix panics that I'm experiencing in the starknet repo when running tests in a debugger

```
panic: invalid argument to Intn

goroutine 28 [running]:
math/rand.(*Rand).Intn(0xc0001ac1b0, 0xfffffffff9babde8)
	/usr/local/go/src/math/rand/rand.go:179 +0xe8
math/rand.Intn(0xfffffffff9babde8)
	/usr/local/go/src/math/rand/rand.go:358 +0x50
github.com/smartcontractkit/chainlink-relay/pkg/utils.WithJitter(0xffffffffe0a5b588)
	/Users/kreherma/go/pkg/mod/github.com/smartcontractkit/chainlink-relay@v0.1.7-0.20230518205430-86610fe3b0a1/pkg/utils/utils.go:16 +0x7c
github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/txm.(*starktxm).confirmLoop(0xc00053a2d0)
```