### PR TITLE
pkg/loop: hclog interopability

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -43,7 +43,7 @@ jobs:
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true
 
-      - name: Verify lint report artifact
+      - name: Print lint report artifact
         if: always()
         run: test -f golangci-lint-report.xml && cat golangci-lint-report.xml || true
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -98,11 +98,6 @@ func (l *logger) with(args ...interface{}) Logger {
 	return &logger{l.SugaredLogger.With(args...), ""}
 }
 
-var (
-	loggerVar    Logger
-	typeOfLogger = reflect.ValueOf(&loggerVar).Elem().Type()
-)
-
 func joinName(old, new string) string {
 	if old == "" {
 		return new
@@ -169,7 +164,8 @@ func Named(l Logger, n string) Logger {
 	return l
 }
 
-// Helper returns a logger 'skip' levels of callers skipped, if 'l' has a method `Helper(int) L`, where L implements Logger, otherwise it returns l.
+// Helper returns a logger with 'skip' levels of callers skipped, if 'l' has a method `Helper(int) L`, where L implements Logger, otherwise it returns l.
+// See [zap.AddCallerSkip]
 func Helper(l Logger, skip int) Logger {
 	switch t := l.(type) {
 	case *logger:
@@ -193,7 +189,7 @@ func Helper(l Logger, skip int) Logger {
 func Critical(l Logger, args ...interface{}) {
 	switch t := l.(type) {
 	case *logger:
-		t.DPanic(args)
+		t.DPanic(args...)
 		return
 	}
 	c, ok := l.(interface {
@@ -203,7 +199,7 @@ func Critical(l Logger, args ...interface{}) {
 		c.Critical(args...)
 		return
 	}
-	l.Error(append([]any{"[crit]"}, args...)...)
+	l.Error(append([]any{"[crit] "}, args...)...)
 }
 
 // Criticalf emits critical level logs (a remapping of [zap.DPanicLevel]) or falls back to error level with a '[crit]' prefix.
@@ -214,10 +210,10 @@ func Criticalf(l Logger, format string, values ...interface{}) {
 		return
 	}
 	c, ok := l.(interface {
-		Critical(format string, values ...interface{})
+		Criticalf(format string, values ...interface{})
 	})
 	if ok {
-		c.Critical(format, values...)
+		c.Criticalf(format, values...)
 		return
 	}
 	l.Errorf("[crit] "+format, values...)
@@ -231,10 +227,10 @@ func Criticalw(l Logger, msg string, keysAndValues ...interface{}) {
 		return
 	}
 	c, ok := l.(interface {
-		Critical(msg string, keysAndValues ...interface{})
+		Criticalw(msg string, keysAndValues ...interface{})
 	})
 	if ok {
-		c.Critical(msg, keysAndValues...)
+		c.Criticalw(msg, keysAndValues...)
 		return
 	}
 	l.Errorw("[crit] "+msg, keysAndValues...)

--- a/pkg/logger/ocr.go
+++ b/pkg/logger/ocr.go
@@ -1,0 +1,55 @@
+package logger
+
+import (
+	ocrtypes "github.com/smartcontractkit/libocr/commontypes"
+)
+
+var _ ocrtypes.Logger = &ocrWrapper{}
+
+type ocrWrapper struct {
+	l         Logger
+	saveError func(string)
+}
+
+// NewOCRWrapper returns a new [ocrtypes.Logger] backed by the given Logger.
+func NewOCRWrapper(l Logger, saveError func(string)) ocrtypes.Logger {
+	return &ocrWrapper{
+		l:         Helper(l, 2),
+		saveError: saveError,
+	}
+}
+func (ol *ocrWrapper) Trace(msg string, fields ocrtypes.LogFields) {
+	Tracew(ol.l, msg, toKeysAndValues(fields)...)
+}
+
+func (ol *ocrWrapper) Debug(msg string, fields ocrtypes.LogFields) {
+	ol.l.Debugw(msg, toKeysAndValues(fields)...)
+}
+
+func (ol *ocrWrapper) Info(msg string, fields ocrtypes.LogFields) {
+	ol.l.Infow(msg, toKeysAndValues(fields)...)
+}
+
+func (ol *ocrWrapper) Warn(msg string, fields ocrtypes.LogFields) {
+	ol.l.Warnw(msg, toKeysAndValues(fields)...)
+}
+
+// Note that the structured fields may contain dynamic data (timestamps etc.)
+// So when saving the error, we only save the top level string, details
+// are included in the log.
+func (ol *ocrWrapper) Error(msg string, fields ocrtypes.LogFields) {
+	ol.saveError(msg)
+	ol.l.Errorw(msg, toKeysAndValues(fields)...)
+}
+
+func (ol *ocrWrapper) Critical(msg string, fields ocrtypes.LogFields) {
+	Criticalw(ol.l, msg, toKeysAndValues(fields)...)
+}
+
+func toKeysAndValues(fields ocrtypes.LogFields) []interface{} {
+	out := []interface{}{}
+	for key, val := range fields {
+		out = append(out, key, val)
+	}
+	return out
+}

--- a/pkg/logger/ocr.go
+++ b/pkg/logger/ocr.go
@@ -14,6 +14,7 @@ type ocrWrapper struct {
 // NewOCRWrapper returns a new [ocrtypes.Logger] backed by the given Logger.
 func NewOCRWrapper(l Logger, saveError func(string)) ocrtypes.Logger {
 	return &ocrWrapper{
+		// Skip an extra level since we are passed along to another wrapper.
 		l:         Helper(l, 2),
 		saveError: saveError,
 	}

--- a/pkg/logger/sugared.go
+++ b/pkg/logger/sugared.go
@@ -1,0 +1,36 @@
+package logger
+
+// SugaredLogger extends the base Logger interface with syntactic sugar, similar to zap.SugaredLogger.
+type SugaredLogger interface {
+	Logger
+	// ErrorIf logs the error if present.
+	ErrorIf(err error, msg string)
+	// ErrorIfFn calls fn() and logs any returned error along with msg.
+	// Unlike ErrorIf, this can be deffered inline, since the function call is delayed.
+	ErrorIfFn(fn func() error, msg string)
+}
+
+// Sugared returns a new SugaredLogger wrapping the given Logger.
+func Sugared(l Logger) SugaredLogger {
+	return &sugared{
+		Logger: l,
+		h:      Helper(l, 1),
+	}
+}
+
+type sugared struct {
+	Logger
+	h Logger // helper with stack trace skip level
+}
+
+func (s *sugared) ErrorIf(err error, msg string) {
+	if err != nil {
+		s.h.Errorw(msg, "err", err)
+	}
+}
+
+func (s *sugared) ErrorIfFn(fn func() error, msg string) {
+	if err := fn(); err != nil {
+		s.h.Errorw(msg, "err", err)
+	}
+}

--- a/pkg/logger/trace.go
+++ b/pkg/logger/trace.go
@@ -6,6 +6,7 @@ const tracePrefix = "[TRACE] "
 
 // Tracew emits trace level logs, which are debug level with a '[trace]' prefix.
 func Tracew(l Logger, msg string, keysAndValues ...interface{}) {
+	l = Helper(l, 1)
 	t, ok := l.(interface {
 		Tracew(string, ...interface{})
 	})
@@ -13,17 +14,18 @@ func Tracew(l Logger, msg string, keysAndValues ...interface{}) {
 		t.Tracew(msg, keysAndValues...)
 		return
 	}
-	l.Helper(1).Debugw(tracePrefix+msg, keysAndValues...)
+	l.Debugw(tracePrefix+msg, keysAndValues...)
 }
 
 // Tracef emits trace level logs, which are debug level with a '[trace]' prefix.
 func Tracef(l Logger, format string, values ...interface{}) {
+	l = Helper(l, 1)
 	t, ok := l.(interface {
 		Tracef(string, ...interface{})
 	})
 	if ok {
-		t.Tracef(msg, keysAndValues...)
+		t.Tracef(format, values...)
 		return
 	}
-	l.Helper(1).Debugf(tracePrefix+format, values...)
+	l.Debugf(tracePrefix+format, values...)
 }

--- a/pkg/logger/trace.go
+++ b/pkg/logger/trace.go
@@ -1,0 +1,29 @@
+//go:build trace
+
+package logger
+
+const tracePrefix = "[TRACE] "
+
+// Tracew emits trace level logs, which are debug level with a '[trace]' prefix.
+func Tracew(l Logger, msg string, keysAndValues ...interface{}) {
+	t, ok := l.(interface {
+		Tracew(string, ...interface{})
+	})
+	if ok {
+		t.Tracew(msg, keysAndValues...)
+		return
+	}
+	l.Helper(1).Debugw(tracePrefix+msg, keysAndValues...)
+}
+
+// Tracef emits trace level logs, which are debug level with a '[trace]' prefix.
+func Tracef(l Logger, format string, values ...interface{}) {
+	t, ok := l.(interface {
+		Tracef(string, ...interface{})
+	})
+	if ok {
+		t.Tracef(msg, keysAndValues...)
+		return
+	}
+	l.Helper(1).Debugf(tracePrefix+format, values...)
+}

--- a/pkg/logger/trace_noop.go
+++ b/pkg/logger/trace_noop.go
@@ -1,0 +1,9 @@
+//go:build !trace
+
+package logger
+
+// Tracew is a no-op.
+func Tracew(l Logger, msg string, keysAndValues ...interface{}) {}
+
+// Tracef is a no-op.
+func Tracef(l Logger, format string, values ...interface{}) {}

--- a/pkg/loop/logger.go
+++ b/pkg/loop/logger.go
@@ -1,0 +1,95 @@
+package loop
+
+import (
+	"io"
+	"sync"
+
+	"github.com/hashicorp/go-hclog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+)
+
+// HCLogLogger returns an [hclog.Logger] backed by the given [logger.Logger].
+func HCLogLogger(l logger.Logger) hclog.Logger {
+	hcl := hclog.NewInterceptLogger(&hclog.LoggerOptions{
+		Output: io.Discard, // only write through p.Logger Sink
+	})
+	hcl.RegisterSink(&hclSinkAdapter{l: l})
+	return hcl
+}
+
+var _ hclog.SinkAdapter = (*hclSinkAdapter)(nil)
+
+// hclSinkAdapter implements [hclog.SinkAdapter] with a [logger.Logger].
+type hclSinkAdapter struct {
+	l logger.Logger
+	m sync.Map // [string]func() l.Logger
+}
+
+func (h *hclSinkAdapter) named(name string) logger.Logger {
+	onceVal := onceValue(func() logger.Logger {
+		return logger.Named(h.l, name)
+	})
+	v, _ := h.m.LoadOrStore(name, onceVal)
+	return v.(func() logger.Logger)()
+}
+
+func (h *hclSinkAdapter) Accept(name string, level hclog.Level, msg string, args ...interface{}) {
+	l := h.named(name)
+	switch level {
+	case hclog.NoLevel:
+	case hclog.Debug, hclog.Trace:
+		l.Debugw(msg, args...)
+	case hclog.Info:
+		l.Infow(msg, args...)
+	case hclog.Warn:
+		l.Warnw(msg, args...)
+	case hclog.Error:
+		l.Errorw(msg, args...)
+	}
+}
+
+// NewLogger returns a new [logger.Logger] configured to encode [hclog] compatible JSON.
+func NewLogger() (logger.Logger, error) {
+	return logger.NewWith(func(cfg *zap.Config) {
+		cfg.Level.SetLevel(zap.DebugLevel)
+		cfg.EncoderConfig.LevelKey = "@level"
+		cfg.EncoderConfig.MessageKey = "@message"
+		cfg.EncoderConfig.TimeKey = "@timestamp"
+		cfg.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout("2006-01-02T15:04:05.000000Z07:00")
+	})
+}
+
+// onceValue returns a function that invokes f only once and returns the value
+// returned by f. The returned function may be called concurrently.
+//
+// If f panics, the returned function will panic with the same value on every call.
+//
+// Note: Copied from sync.OnceValue in upcoming 1.21 release. Can be removed after upgrading.
+func onceValue[T any](f func() T) func() T {
+	var (
+		once   sync.Once
+		valid  bool
+		p      any
+		result T
+	)
+	g := func() {
+		defer func() {
+			p = recover()
+			if !valid {
+				panic(p)
+			}
+		}()
+		result = f()
+		valid = true
+	}
+	return func() T {
+		once.Do(g)
+		if !valid {
+			panic(p)
+		}
+		return result
+	}
+}

--- a/pkg/loop/plugin_median.go
+++ b/pkg/loop/plugin_median.go
@@ -56,5 +56,6 @@ func (p *GRPCPluginMedian) ClientConfig() *plugin.ClientConfig {
 		Plugins:          map[string]plugin.Plugin{PluginMedianName: p},
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		GRPCDialOptions:  p.DialOpts,
+		Logger:           HCLogLogger(p.Logger),
 	}
 }

--- a/pkg/loop/plugin_relayer.go
+++ b/pkg/loop/plugin_relayer.go
@@ -58,5 +58,6 @@ func (p *GRPCPluginRelayer) ClientConfig() *plugin.ClientConfig {
 		Plugins:          map[string]plugin.Plugin{PluginRelayerName: p},
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		GRPCDialOptions:  p.DialOpts,
+		Logger:           HCLogLogger(p.Logger),
 	}
 }


### PR DESCRIPTION
This PR updates various logging code to support inter-operating with `package hclog`, in order to allow loop logs to be interpreted and forwarded properly by hashicorp/go-plugin.
 - added `loop.NewLogger()` to create a `logger.Logger` which write hclog fields names
 - added `loop.HCLogLogger()` to create an `hclog.Logger` which is backed by one of our own `Logger`s
 - move `NewOCRWrapper` from core
 - add trace and critical helpers to support migrating plugins away from `core/logger.Logger`

Supports:
- https://github.com/smartcontractkit/chainlink/pull/9551