### PR TITLE
Cleanup Common Fee Test

### DIFF
--- a/pkg/fee/models_test.go
+++ b/pkg/fee/models_test.go
@@ -19,12 +19,12 @@ func TestCalculateFee(t *testing.T) {
 
 	t.Run("CalculateFee returns UserSpecifiedMaxFeePrice when it's lower than DefaultPrice and MaxFeePriceConfigured", func(t *testing.T) {
 		cfg := newMockFeeEstimatorConfig(&mockFeeEstimatorConfig{
-			UserSpecifiedMaxFeePrice: big.NewInt(1000000),
+			UserSpecifiedMaxFeePrice: big.NewInt(30),
 			DefaultPrice:             big.NewInt(42),
 			MultiplierLimit:          1.1,
 			MaxFeePriceConfigured:    big.NewInt(35),
 		})
-		assert.Equal(t, big.NewInt(30), CalculateFee(big.NewInt(30), cfg.DefaultPrice, cfg.MaxFeePriceConfigured))
+		assert.Equal(t, big.NewInt(30), CalculateFee(cfg.UserSpecifiedMaxFeePrice, cfg.DefaultPrice, cfg.MaxFeePriceConfigured))
 	})
 
 	t.Run("CalculateFee returns global maximum price", func(t *testing.T) {


### PR DESCRIPTION
This is a fix that is non breaking or affect the functionality

I made a mistake of leaving in a redundant component in the test that i wrote previously. It is non breaking, non functional change. Wanted to make sure that this gets removed before my internship ends.

This will help to clarify the logic of how `CalculateFee` works when developers look at our test.
