### PR TITLE
remove chainset interface

### DIFF
--- a/pkg/types/relayer.go
+++ b/pkg/types/relayer.go
@@ -46,20 +46,6 @@ type Relayer interface {
 }
 
 // Deprecated
-type ChainSet[I any, C ChainService] interface {
-	Service
-
-	Chain(ctx context.Context, id I) (C, error)
-
-	ChainStatus(ctx context.Context, id string) (ChainStatus, error)
-	ChainStatuses(ctx context.Context, offset, limit int) (chains []ChainStatus, count int, err error)
-
-	NodeStatuses(ctx context.Context, offset, limit int, chainIDs ...string) (nodes []NodeStatus, count int, err error)
-
-	SendTx(ctx context.Context, chainID, from, to string, amount *big.Int, balanceCheck bool) error
-}
-
-// Deprecated
 type ChainService interface {
 	Service
 


### PR DESCRIPTION
BCF-2440 removed the ChainSet dep from core
BCF-2562 removed it from the chain repos.

We can delete from here now.