### PR TITLE
Silence spurious errors

### DIFF
--- a/pkg/reportingplugins/mercury/v2/mercury.go
+++ b/pkg/reportingplugins/mercury/v2/mercury.go
@@ -287,13 +287,16 @@ func (rp *reportingPlugin) Report(repts ocrtypes.ReportTimestamp, previousReport
 		return false, nil, err
 	}
 
+	if rf.Timestamp < rf.ValidFromTimestamp {
+		rp.logger.Debugw("shouldReport: no (overlap)", "observationTimestamp", rf.Timestamp, "validFromTimestamp", rf.ValidFromTimestamp, "repts", repts)
+		return false, nil, nil
+	}
+
 	if err = rp.validateReport(rf); err != nil {
-		rp.logger.Debugw("shouldReport: no (validation error)", "err", err, "timestamp", repts)
+		rp.logger.Debugw("shouldReport: no (validation error)", "err", err, "repts", repts)
 		return false, nil, err
 	}
-	rp.logger.Debugw("shouldReport: yes",
-		"timestamp", repts,
-	)
+	rp.logger.Debugw("shouldReport: yes", "repts", repts)
 
 	report, err = rp.reportCodec.BuildReport(rf)
 	if err != nil {

--- a/pkg/reportingplugins/mercury/v2/mercury_test.go
+++ b/pkg/reportingplugins/mercury/v2/mercury_test.go
@@ -35,6 +35,7 @@ type testReportCodec struct {
 	builtReport          ocrtypes.Report
 
 	builtReportFields *ReportFields
+	err               error
 }
 
 func (rc *testReportCodec) BuildReport(rf ReportFields) (ocrtypes.Report, error) {
@@ -48,7 +49,7 @@ func (rc testReportCodec) MaxReportLength(n int) (int, error) {
 }
 
 func (rc testReportCodec) ObservationTimestampFromReport(ocrtypes.Report) (uint32, error) {
-	return rc.observationTimestamp, nil
+	return rc.observationTimestamp, rc.err
 }
 
 func newAttributedObservation(t *testing.T, p *MercuryObservationProto) ocrtypes.AttributedObservation {
@@ -311,7 +312,28 @@ func Test_Plugin_Report(t *testing.T) {
 			}, *codec.builtReportFields)
 
 		})
-		t.Run("errors if cannot extract timestamp from previous report", func(t *testing.T) {})
+		t.Run("errors if cannot extract timestamp from previous report", func(t *testing.T) {
+			codec.err = errors.New("something exploded trying to extract timestamp")
+			aos := newValidAos(t)
+
+			should, _, err := rp.Report(ocrtypes.ReportTimestamp{}, previousReport, aos)
+			assert.False(t, should)
+			assert.EqualError(t, err, "something exploded trying to extract timestamp")
+		})
+		t.Run("does not report if observationTimestamp < validFromTimestamp", func(t *testing.T) {
+			codec.observationTimestamp = 43
+			codec.err = nil
+
+			protos := newValidProtos()
+			for i := range protos {
+				protos[i].Timestamp = 42
+			}
+			aos := newValidAos(t, protos...)
+
+			should, _, err := rp.Report(ocrtypes.ReportTimestamp{}, previousReport, aos)
+			assert.False(t, should)
+			assert.NoError(t, err)
+		})
 	})
 
 	t.Run("buildReport failures", func(t *testing.T) {

--- a/pkg/reportingplugins/mercury/v3/mercury.go
+++ b/pkg/reportingplugins/mercury/v3/mercury.go
@@ -322,13 +322,16 @@ func (rp *reportingPlugin) Report(repts ocrtypes.ReportTimestamp, previousReport
 		return false, nil, err
 	}
 
+	if rf.Timestamp < rf.ValidFromTimestamp {
+		rp.logger.Debugw("shouldReport: no (overlap)", "observationTimestamp", rf.Timestamp, "validFromTimestamp", rf.ValidFromTimestamp, "repts", repts)
+		return false, nil, nil
+	}
+
 	if err = rp.validateReport(rf); err != nil {
-		rp.logger.Debugw("shouldReport: no (validation error)", "err", err, "timestamp", repts)
+		rp.logger.Debugw("shouldReport: no (validation error)", "err", err, "repts", repts)
 		return false, nil, err
 	}
-	rp.logger.Debugw("shouldReport: yes",
-		"timestamp", repts,
-	)
+	rp.logger.Debugw("shouldReport: yes", "repts", repts)
 
 	report, err = rp.reportCodec.BuildReport(rf)
 	if err != nil {


### PR DESCRIPTION
This case is common when we try to generate another report for the same
given second, e.g. if we already have 42..43 and it is still second 43,
so we try to generate 43..43 again. This isn't an error but it should be
ignored and not reported.
