### PR TITLE
pkg/loop: fix HCLogLogger to preserve logger names

### DIFF
--- a/pkg/loop/logger_test.go
+++ b/pkg/loop/logger_test.go
@@ -1,0 +1,71 @@
+package loop_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/grpc"
+
+	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
+)
+
+const PluginLoggerTestName = "logger-test"
+
+const LoggerTestName = "server-side-logger-name"
+
+func TestHCLogLogger(t *testing.T) {
+	lggr, ol := logger.TestObserved(t, zapcore.ErrorLevel)
+	loggerTest := &GRPCPluginLoggerTest{Logger: lggr}
+	cc := loggerTest.ClientConfig()
+	cc.Cmd = helperProcess(PluginLoggerTestName)
+	c := plugin.NewClient(cc)
+	t.Cleanup(c.Kill)
+	_, err := c.Client()
+	require.Error(t, err)
+
+	// Some logs should come through with plugin-side names
+	require.NotEmpty(t, ol.Filter(func(entry observer.LoggedEntry) bool {
+		return entry.LoggerName == LoggerTestName
+	}), ol.All())
+}
+
+type GRPCPluginLoggerTest struct {
+	plugin.NetRPCUnsupportedPlugin
+
+	logger.Logger
+}
+
+func (g *GRPCPluginLoggerTest) GRPCServer(*plugin.GRPCBroker, *grpc.Server) (err error) {
+	err = errors.New("test error")
+	g.Logger.Errorw("Error!", "err", err)
+	g.Logger.Sync()
+	time.Sleep(time.Second)
+	return err
+}
+
+func (g *GRPCPluginLoggerTest) GRPCClient(context.Context, *plugin.GRPCBroker, *grpc.ClientConn) (interface{}, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (g *GRPCPluginLoggerTest) ClientConfig() *plugin.ClientConfig {
+	return &plugin.ClientConfig{
+		HandshakeConfig:  PluginLoggerTestHandshakeConfig(),
+		Plugins:          map[string]plugin.Plugin{PluginLoggerTestName: g},
+		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
+		Logger:           loop.HCLogLogger(g.Logger),
+	}
+}
+
+func PluginLoggerTestHandshakeConfig() plugin.HandshakeConfig {
+	return plugin.HandshakeConfig{
+		MagicCookieKey:   "CL_PLUGIN_LOGGER_TEST_MAGIC_COOKIE",
+		MagicCookieValue: "272d1867cdc8042f9405d7c1da3762ec",
+	}
+}

--- a/pkg/loop/plugin_test.go
+++ b/pkg/loop/plugin_test.go
@@ -124,6 +124,12 @@ func TestHelperProcess(t *testing.T) {
 		}
 	}
 
+	lggr, err := loop.NewLogger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create logger: %s\n", err)
+		os.Exit(2)
+	}
+
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	switch cmd {
@@ -131,7 +137,7 @@ func TestHelperProcess(t *testing.T) {
 		plugin.Serve(&plugin.ServeConfig{
 			HandshakeConfig: loop.PluginRelayerHandshakeConfig(),
 			Plugins: map[string]plugin.Plugin{
-				loop.PluginRelayerName: &loop.GRPCPluginRelayer{PluginServer: test.StaticPluginRelayer{}, BrokerConfig: loop.BrokerConfig{Logger: logger.Test(t), StopCh: stopCh}},
+				loop.PluginRelayerName: &loop.GRPCPluginRelayer{PluginServer: test.StaticPluginRelayer{}, BrokerConfig: loop.BrokerConfig{Logger: lggr, StopCh: stopCh}},
 			},
 			GRPCServer: grpcServer,
 		})
@@ -141,11 +147,21 @@ func TestHelperProcess(t *testing.T) {
 		plugin.Serve(&plugin.ServeConfig{
 			HandshakeConfig: loop.PluginMedianHandshakeConfig(),
 			Plugins: map[string]plugin.Plugin{
-				loop.PluginRelayerName: &loop.GRPCPluginMedian{PluginServer: test.StaticPluginMedian{}, BrokerConfig: loop.BrokerConfig{Logger: logger.Test(t), StopCh: stopCh}},
+				loop.PluginMedianName: &loop.GRPCPluginMedian{PluginServer: test.StaticPluginMedian{}, BrokerConfig: loop.BrokerConfig{Logger: lggr, StopCh: stopCh}},
 			},
 			GRPCServer: grpcServer,
 		})
 		os.Exit(0)
+
+	case PluginLoggerTestName:
+		loggerTest := &GRPCPluginLoggerTest{Logger: logger.Named(lggr, LoggerTestName)}
+		plugin.Serve(&plugin.ServeConfig{
+			HandshakeConfig: PluginLoggerTestHandshakeConfig(),
+			Plugins: map[string]plugin.Plugin{
+				PluginLoggerTestName: loggerTest,
+			},
+			GRPCServer: grpcServer,
+		})
 
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %q\n", cmd)


### PR DESCRIPTION
I noticed that we were logging two `logger` keys for the 'name', which is a bug, and not handled well by grafana.
This fixes the `hclSinkAdapter` and adds a test to ensure that the server side log name is observed in the test output.