### PR TITLE
pkg/services/srvctest: add helper for testing HealthReport names

### DIFF
--- a/pkg/loop/internal/test/relayer.go
+++ b/pkg/loop/internal/test/relayer.go
@@ -62,12 +62,13 @@ func (s staticRelayer) Start(ctx context.Context) error { return nil }
 
 func (s staticRelayer) Close() error { return nil }
 
-func (s staticRelayer) Ready() error { panic("unimplemented") }
+func (s staticRelayer) Ready() error { return nil }
 
-func (s staticRelayer) Name() string { panic("unimplemented") }
+func (s staticRelayer) Name() string { return "staticRelayer" }
 
-func (s staticRelayer) HealthReport() map[string]error { panic("unimplemented") }
-
+func (s staticRelayer) HealthReport() map[string]error {
+	return map[string]error{s.Name(): s.Ready()}
+}
 func (s staticRelayer) NewConfigProvider(ctx context.Context, r types.RelayArgs) (types.ConfigProvider, error) {
 	if !equalRelayArgs(r, RelayArgs) {
 		return nil, fmt.Errorf("expected relay args:\n\t%v\nbut got:\n\t%v", RelayArgs, r)

--- a/pkg/loop/relayer_service_test.go
+++ b/pkg/loop/relayer_service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
 	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
 	"github.com/smartcontractkit/chainlink-relay/pkg/loop/internal/test"
+	"github.com/smartcontractkit/chainlink-relay/pkg/services/srvctest"
 	"github.com/smartcontractkit/chainlink-relay/pkg/utils/tests"
 )
 
@@ -58,4 +59,24 @@ func TestRelayerService_recovery(t *testing.T) {
 	t.Cleanup(func() { assert.NoError(t, relayer.Close()) })
 
 	test.TestRelayer(t, relayer)
+}
+
+func TestRelayerService_HealthReport(t *testing.T) {
+	lggr := logger.Named(logger.Test(t), "Foo")
+	s := loop.NewRelayerService(lggr, loop.GRPCOpts{}, func() *exec.Cmd {
+		return helperProcess(loop.PluginRelayerName)
+	}, test.ConfigTOML, test.StaticKeystore{})
+
+	srvctest.AssertHealthReportNames(t, s.HealthReport(),
+		"Foo.RelayerService")
+
+	require.NoError(t, s.Start(tests.Context(t)))
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	require.Eventually(t, func() bool { return s.Ready() == nil }, tests.WaitTimeout(t)/2, time.Second, s.Ready())
+
+	srvctest.AssertHealthReportNames(t, s.HealthReport(),
+		"Foo.RelayerService",
+		"Foo.RelayerService.PluginRelayerClient.ChainRelayerClient",
+		"staticRelayer")
 }

--- a/pkg/services/srvctest/health.go
+++ b/pkg/services/srvctest/health.go
@@ -1,0 +1,17 @@
+package srvctest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+func AssertHealthReportNames(t *testing.T, hp map[string]error, names ...string) {
+	t.Helper()
+	keys := maps.Keys(hp)
+	slices.Sort(keys)
+	slices.Sort(names)
+	assert.EqualValues(t, names, keys)
+}


### PR DESCRIPTION
Add a `srvctest.AssertHealthReportNames` helper for verifying service names from `HealthReport()` results.