### PR TITLE
[BCF-2463] Fix incorrect usage of the telemetryClient in the LOOPP service

### DIFF
--- a/pkg/loop/internal/reporting_plugin_service.go
+++ b/pkg/loop/internal/reporting_plugin_service.go
@@ -31,7 +31,7 @@ func (m *ReportingPluginServiceClient) NewReportingPluginFactory(
 	config types.ReportingPluginServiceConfig,
 	grpcProvider grpc.ClientConnInterface,
 	pipelineRunner types.PipelineRunnerService,
-	telemetry types.TelemetryClient,
+	telemetry types.TelemetryService,
 	errorLog types.ErrorLog,
 ) (types.ReportingPluginFactory, error) {
 	cc := m.newClientConn("ReportingPluginServiceFactory", func(ctx context.Context) (id uint32, deps resources, err error) {
@@ -132,7 +132,7 @@ func (m *reportingPluginServiceServer) NewReportingPluginFactory(ctx context.Con
 		return nil, ErrConnDial{Name: "Telemetry", ID: request.TelemetryID, Err: err}
 	}
 	telemetryRes := resource{telemetryConn, "Telemetry"}
-	telemetry := NewTelemetryClient(telemetryConn)
+	telemetry := NewTelemetryServiceClient(telemetryConn)
 
 	config := types.ReportingPluginServiceConfig{
 		ProviderType: request.ReportingPluginServiceConfig.ProviderType,

--- a/pkg/loop/internal/test/telemetry.go
+++ b/pkg/loop/internal/test/telemetry.go
@@ -70,8 +70,8 @@ func (m mockClientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, me
 }
 
 func Telemetry(t *testing.T) {
-	mcc := mockClientConn{}
-	c := internal.NewTelemetryClient(&mcc)
+	tsc := internal.NewTelemetryServiceClient(mockClientConn{})
+	c := internal.NewTelemetryClient(tsc)
 
 	type sendTest struct {
 		contractID    string

--- a/pkg/loop/reportingplugins/grpc.go
+++ b/pkg/loop/reportingplugins/grpc.go
@@ -44,7 +44,7 @@ type serverAdapter func(
 	types.ReportingPluginServiceConfig,
 	grpc.ClientConnInterface,
 	types.PipelineRunnerService,
-	types.TelemetryClient,
+	types.TelemetryService,
 	types.ErrorLog,
 ) (types.ReportingPluginFactory, error)
 
@@ -53,7 +53,7 @@ func (s serverAdapter) NewReportingPluginFactory(
 	config types.ReportingPluginServiceConfig,
 	conn grpc.ClientConnInterface,
 	pr types.PipelineRunnerService,
-	ts types.TelemetryClient,
+	ts types.TelemetryService,
 	errorLog types.ErrorLog,
 ) (types.ReportingPluginFactory, error) {
 	return s(ctx, config, conn, pr, ts, errorLog)
@@ -65,11 +65,12 @@ func (g *GRPCService[T]) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Serv
 		cfg types.ReportingPluginServiceConfig,
 		conn grpc.ClientConnInterface,
 		pr types.PipelineRunnerService,
-		ts types.TelemetryClient,
+		ts types.TelemetryService,
 		el types.ErrorLog,
 	) (types.ReportingPluginFactory, error) {
 		provider := g.PluginServer.ConnToProvider(conn, broker, g.BrokerConfig)
-		return g.PluginServer.NewReportingPluginFactory(ctx, cfg, provider, pr, ts, el)
+		tc := internal.NewTelemetryClient(ts)
+		return g.PluginServer.NewReportingPluginFactory(ctx, cfg, provider, pr, tc, el)
 	}
 	return internal.RegisterReportingPluginServiceServer(server, broker, g.BrokerConfig, serverAdapter(adapter))
 }

--- a/pkg/loop/reportingplugins/loopp_service.go
+++ b/pkg/loop/reportingplugins/loopp_service.go
@@ -31,7 +31,7 @@ func NewLOOPPService(
 	config types.ReportingPluginServiceConfig,
 	providerConn grpc.ClientConnInterface,
 	pipelineRunner types.PipelineRunnerService,
-	telemetryService types.TelemetryClient,
+	telemetryService types.TelemetryService,
 	errorLog types.ErrorLog,
 ) *LOOPPService {
 	newService := func(ctx context.Context, instance any) (types.ReportingPluginFactory, error) {

--- a/pkg/types/reporting_plugin_service.go
+++ b/pkg/types/reporting_plugin_service.go
@@ -16,7 +16,7 @@ type ReportingPluginServiceConfig struct {
 // ReportingPluginClient is the client interface to a plugin running
 // as a generic job (job type = GenericPlugin) inside the core node.
 type ReportingPluginClient interface {
-	NewReportingPluginFactory(ctx context.Context, config ReportingPluginServiceConfig, grpcProvider grpc.ClientConnInterface, pipelineRunner PipelineRunnerService, telemetry TelemetryClient, errorLog ErrorLog) (ReportingPluginFactory, error)
+	NewReportingPluginFactory(ctx context.Context, config ReportingPluginServiceConfig, grpcProvider grpc.ClientConnInterface, pipelineRunner PipelineRunnerService, telemetry TelemetryService, errorLog ErrorLog) (ReportingPluginFactory, error)
 }
 
 // ReportingPluginServer is the server interface to a plugin running


### PR DESCRIPTION
In my previous PR, I incorrectly added types.TelemetryClient rather than types.TelemetryService to the interface definition for the ReportingPluginServiceServer.