### PR TITLE
Fix Tracing Dial to Otel Collector

### DIFF
--- a/pkg/loop/server.go
+++ b/pkg/loop/server.go
@@ -73,6 +73,7 @@ func (s *Server) start() error {
 		CollectorTarget: envCfg.TracingCollectorTarget,
 		NodeAttributes:  envCfg.TracingAttributes,
 		SamplingRatio:   envCfg.TracingSamplingRatio,
+		OnDialError:     func(err error) { s.Logger.Errorw("Failed to dial", "err", err) },
 	}); err != nil {
 		// non blocking to server start
 		s.Logger.Errorf("Failed to setup tracing: %s", err)

--- a/pkg/loop/telem.go
+++ b/pkg/loop/telem.go
@@ -2,7 +2,6 @@ package loop
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"runtime/debug"
@@ -39,6 +38,9 @@ type TracingConfig struct {
 
 	// SamplingRatio is the ratio of traces to sample. 1.0 means sample all traces.
 	SamplingRatio float64
+
+	// OnDialError is called when the dialer fails, providing an opportunity to log.
+	OnDialError func(error)
 }
 
 // NewGRPCOpts initializes open telemetry and returns GRPCOpts with telemetry interceptors.
@@ -70,7 +72,7 @@ func SetupTracing(config TracingConfig) error {
 		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 			conn, err := net.Dial("tcp", s)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to dial: %v", err)
+				config.OnDialError(err)
 			}
 			return conn, err
 		}))


### PR DESCRIPTION
Corresponding core PR: https://github.com/smartcontractkit/chainlink/pull/11172

Previously, the trace exporter would silently fail if there was a failure to connect to the otel collector. This fixes dial issues with the otel collector and also ensures there is a log line for failures. 

The default log line when the otel-collector is un-dialable is plain text, which won't show up in grafana. 

Log line:
```
failed to dial: dial tcp: lookup otel-collector on 127.0.0.11:53: no such host
```

We've added `OnDialError` to the `TracingConfig` struct so that consumers of `SetupTracing` can wire a logger through. 