### PR TITLE
mercury: Add ChainReader to MercuryProvider

### DIFF
--- a/pkg/reportingplugins/mercury/types.go
+++ b/pkg/reportingplugins/mercury/types.go
@@ -44,10 +44,10 @@ type Transmitter interface {
 
 type ChainReader interface {
 	// LatestBlocks returns an ordered list of the latest specified number of blocks
-	LatestBlocks(context.Context, int) ([]Block, error)
+	LatestBlocks(context.Context, int) ([]Head, error)
 }
 
-type Block struct {
+type Head struct {
 	Number    uint64
 	Hash      []byte
 	Timestamp uint64

--- a/pkg/reportingplugins/mercury/types.go
+++ b/pkg/reportingplugins/mercury/types.go
@@ -43,8 +43,8 @@ type Transmitter interface {
 }
 
 type ChainReader interface {
-	// LatestBlocks returns an ordered list of the latest specified number of blocks
-	LatestBlocks(context.Context, int) ([]Head, error)
+	// LatestHeads returns an ordered list of the latest specified number of heads
+	LatestHeads(context.Context, int) ([]Head, error)
 }
 
 type Head struct {

--- a/pkg/reportingplugins/mercury/types.go
+++ b/pkg/reportingplugins/mercury/types.go
@@ -43,8 +43,6 @@ type Transmitter interface {
 }
 
 type ChainReader interface {
-	// Head returns the current chain head
-	Head(context.Context) (Block, error)
 	// LatestBlocks returns an ordered list of the latest specified number of blocks
 	LatestBlocks(context.Context, int) ([]Block, error)
 }

--- a/pkg/reportingplugins/mercury/types.go
+++ b/pkg/reportingplugins/mercury/types.go
@@ -41,3 +41,16 @@ type Transmitter interface {
 	// - FromAccount() should return CSA public key
 	ocrtypes.ContractTransmitter
 }
+
+type ChainReader interface {
+	// Head returns the current chain head
+	Head(context.Context) (Block, error)
+	// LatestBlocks returns an ordered list of the latest specified number of blocks
+	LatestBlocks(context.Context, int) ([]Block, error)
+}
+
+type Block struct {
+	Number    uint64
+	Hash      []byte
+	Timestamp uint64
+}

--- a/pkg/types/provider_mercury.go
+++ b/pkg/types/provider_mercury.go
@@ -17,4 +17,5 @@ type MercuryProvider interface {
 	ReportCodecV3() v3.ReportCodec
 	OnchainConfigCodec() mercury.OnchainConfigCodec
 	MercuryServerFetcher() mercury.MercuryServerFetcher
+	ChainReader() mercury.ChainReader
 }


### PR DESCRIPTION
This change adds ChainReader() (ChainHead) interface and type to the MercuryProvider relayer to enable the removal of the plugin dependency on the raw evm chain.