### PR TITLE
pkt/utils: simpler LazyLoad

### DIFF
--- a/pkg/utils/lazy.go
+++ b/pkg/utils/lazy.go
@@ -7,8 +7,8 @@ import (
 type LazyLoad[T any] struct {
 	f     func() (T, error)
 	state T
+	ok    bool
 	lock  sync.Mutex
-	once  sync.Once
 }
 
 func NewLazyLoad[T any](f func() (T, error)) *LazyLoad[T] {
@@ -21,20 +21,16 @@ func (l *LazyLoad[T]) Get() (out T, err error) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
-	// fetch only once (or whenever cleared)
-	l.once.Do(func() {
-		l.state, err = l.f()
-	})
-	// if err, clear so next get will retry
-	if err != nil {
-		l.once = sync.Once{}
+	if l.ok {
+		return l.state, nil
 	}
-	out = l.state
-	return
+	l.state, err = l.f()
+	l.ok = err == nil
+	return l.state, err
 }
 
 func (l *LazyLoad[T]) Reset() {
 	l.lock.Lock()
 	defer l.lock.Unlock()
-	l.once = sync.Once{}
+	l.ok = false
 }


### PR DESCRIPTION
Simplify `LazyLoad` by dropping unnecessary synchronization. Mirrors changes from core.