### PR TITLE
pkg/config: move config types from utils

### DIFF
--- a/pkg/config/duration.go
+++ b/pkg/config/duration.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Duration is a non-negative time duration.
+type Duration struct{ d time.Duration }
+
+func NewDuration(d time.Duration) (Duration, error) {
+	if d < time.Duration(0) {
+		return Duration{}, fmt.Errorf("cannot make negative time duration: %s", d)
+	}
+	return Duration{d: d}, nil
+}
+
+func MustNewDuration(d time.Duration) *Duration {
+	rv, err := NewDuration(d)
+	if err != nil {
+		panic(err)
+	}
+	return &rv
+}
+
+func (d Duration) Duration() time.Duration {
+	return d.d
+}
+
+func (d Duration) String() string {
+	return d.d.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (d *Duration) UnmarshalJSON(input []byte) error {
+	var txt string
+	err := json.Unmarshal(input, &txt)
+	if err != nil {
+		return err
+	}
+	v, err := time.ParseDuration(string(txt))
+	if err != nil {
+		return err
+	}
+	*d, err = NewDuration(v)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalText implements the text.Marshaler interface.
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(d.d.String()), nil
+}
+
+// UnmarshalText implements the text.Unmarshaler interface.
+func (d *Duration) UnmarshalText(input []byte) error {
+	v, err := time.ParseDuration(string(input))
+	if err != nil {
+		return err
+	}
+	pd, err := NewDuration(v)
+	if err != nil {
+		return err
+	}
+	*d = pd
+	return nil
+}
+
+func (d *Duration) Scan(v interface{}) (err error) {
+	switch tv := v.(type) {
+	case int64:
+		*d, err = NewDuration(time.Duration(tv))
+		return err
+	default:
+		return errors.Errorf(`don't know how to parse "%s" of type %T as a `+
+			`models.Duration`, tv, tv)
+	}
+}
+
+func (d Duration) Value() (driver.Value, error) {
+	return int64(d.d), nil
+}

--- a/pkg/config/url.go
+++ b/pkg/config/url.go
@@ -1,0 +1,35 @@
+package config
+
+import "net/url"
+
+// URL extends url.URL to implement encoding.TextMarshaler.
+type URL url.URL
+
+func ParseURL(s string) (*URL, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	return (*URL)(u), nil
+}
+
+func MustParseURL(s string) *URL {
+	u, err := ParseURL(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func (u *URL) MarshalText() ([]byte, error) {
+	return []byte((*url.URL)(u).String()), nil
+}
+
+func (u *URL) UnmarshalText(input []byte) error {
+	v, err := url.Parse(string(input))
+	if err != nil {
+		return err
+	}
+	*u = URL(*v)
+	return nil
+}

--- a/pkg/loop/context_test.go
+++ b/pkg/loop/context_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-relay/pkg/config"
 )
 
 func TestContextValues(t *testing.T) {
@@ -19,14 +19,14 @@ func TestContextValues(t *testing.T) {
 		{name: "full", vals: ContextValues{
 			JobID:         42,
 			JobName:       "name",
-			ContractID:    utils.MustParseURL("http://example.com"),
+			ContractID:    config.MustParseURL("http://example.com"),
 			FeedID:        big.NewInt(1234567890987654321),
 			TransmitterID: "0xfake-test-id",
 		}, len: 10},
 		{name: "feedless", vals: ContextValues{
 			JobID:      42,
 			JobName:    "name",
-			ContractID: utils.MustParseURL("http://example.com"),
+			ContractID: config.MustParseURL("http://example.com"),
 		}, len: 6},
 		{name: "empty", vals: ContextValues{}, len: 0},
 	} {

--- a/pkg/utils/duration.go
+++ b/pkg/utils/duration.go
@@ -1,93 +1,16 @@
 package utils
 
 import (
-	"database/sql/driver"
-	"encoding/json"
-	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink-relay/pkg/config"
 )
 
-// Duration is a non-negative time duration.
-type Duration struct{ d time.Duration }
+// Deprecated: use config.Duration
+type Duration = config.Duration
 
-func NewDuration(d time.Duration) (Duration, error) {
-	if d < time.Duration(0) {
-		return Duration{}, fmt.Errorf("cannot make negative time duration: %s", d)
-	}
-	return Duration{d: d}, nil
-}
+// Deprecated: use config.NewDuration
+func NewDuration(d time.Duration) (Duration, error) { return config.NewDuration(d) }
 
-func MustNewDuration(d time.Duration) *Duration {
-	rv, err := NewDuration(d)
-	if err != nil {
-		panic(err)
-	}
-	return &rv
-}
-
-func (d Duration) Duration() time.Duration {
-	return d.d
-}
-
-func (d Duration) String() string {
-	return d.d.String()
-}
-
-// MarshalJSON implements the json.Marshaler interface.
-func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.String())
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface.
-func (d *Duration) UnmarshalJSON(input []byte) error {
-	var txt string
-	err := json.Unmarshal(input, &txt)
-	if err != nil {
-		return err
-	}
-	v, err := time.ParseDuration(string(txt))
-	if err != nil {
-		return err
-	}
-	*d, err = NewDuration(v)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalText implements the text.Marshaler interface.
-func (d Duration) MarshalText() ([]byte, error) {
-	return []byte(d.d.String()), nil
-}
-
-// UnmarshalText implements the text.Unmarshaler interface.
-func (d *Duration) UnmarshalText(input []byte) error {
-	v, err := time.ParseDuration(string(input))
-	if err != nil {
-		return err
-	}
-	pd, err := NewDuration(v)
-	if err != nil {
-		return err
-	}
-	*d = pd
-	return nil
-}
-
-func (d *Duration) Scan(v interface{}) (err error) {
-	switch tv := v.(type) {
-	case int64:
-		*d, err = NewDuration(time.Duration(tv))
-		return err
-	default:
-		return errors.Errorf(`don't know how to parse "%s" of type %T as a `+
-			`models.Duration`, tv, tv)
-	}
-}
-
-func (d Duration) Value() (driver.Value, error) {
-	return int64(d.d), nil
-}
+// Deprecated: use config.MustNewDuration
+func MustNewDuration(d time.Duration) *Duration { return config.MustNewDuration(d) }

--- a/pkg/utils/subprocesses.go
+++ b/pkg/utils/subprocesses.go
@@ -4,29 +4,29 @@ import "sync"
 
 // Subprocesses is an abstraction over the following pattern of sync.WaitGroup:
 //
-// var wg sync.Subprocesses
-// wg.Add(1)
-// go func() {
-// defer wg.Done()
-// ...
-// }()
+//	var wg sync.Subprocesses
+//	wg.Add(1)
+//	go func() {
+//	defer wg.Done()
+//	...
+//	}()
 //
-// Which becomes:
+//	Which becomes:
 //
-// var subs utils.Subprocesses
-// subs.Go(func() {
-// ...
-// })
+//	var subs utils.Subprocesses
+//	subs.Go(func() {
+//	...
+//	})
 //
 // Note that it's important to not call Subprocesses.Wait() when there are
 // no `Go()`ed functions in progress. This will panic.
 // There are two cases when this can happen:
-// 1. all the `Go()`ed functions started before the call to `Wait()` have already
-// returned, maybe because a system-wide error or an already cancelled context.
-// 2. Wait() gets called before any function is executed with `Go()`.
+//  1. all the `Go()`ed functions started before the call to `Wait()` have already
+//     returned, maybe because a system-wide error or an already cancelled context.
+//  2. Wait() gets called before any function is executed with `Go()`.
 //
 // Reusing a Subprocesses instance is discouraged.
-// See mode details here https://pkg.go.dev/sync#WaitGroup.Add)
+// See mode details here https://pkg.go.dev/sync#WaitGroup.Add
 type Subprocesses struct {
 	wg sync.WaitGroup
 }

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -1,35 +1,12 @@
 package utils
 
-import "net/url"
+import "github.com/smartcontractkit/chainlink-relay/pkg/config"
 
-// URL extends url.URL to implement encoding.TextMarshaler.
-type URL url.URL
+// Deprecated: use config.URL
+type URL = config.URL
 
-func ParseURL(s string) (*URL, error) {
-	u, err := url.Parse(s)
-	if err != nil {
-		return nil, err
-	}
-	return (*URL)(u), nil
-}
+// Deprecated: use config.ParseURL
+func ParseURL(s string) (*URL, error) { return config.ParseURL(s) }
 
-func MustParseURL(s string) *URL {
-	u, err := ParseURL(s)
-	if err != nil {
-		panic(err)
-	}
-	return u
-}
-
-func (u *URL) MarshalText() ([]byte, error) {
-	return []byte((*url.URL)(u).String()), nil
-}
-
-func (u *URL) UnmarshalText(input []byte) error {
-	v, err := url.Parse(string(input))
-	if err != nil {
-		return err
-	}
-	*u = URL(*v)
-	return nil
-}
+// Deprecated: use config.MustParseURL
+func MustParseURL(s string) *URL { return config.MustParseURL(s) }


### PR DESCRIPTION
This PR moves the toml config types from `package utils` to `package config` (and leaves behind deprecated aliases).